### PR TITLE
German translation

### DIFF
--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -102,6 +102,11 @@ Page {
                 myText: qsTr(" - French translation")
             }
 
+            AuthorRow {
+                author: "rabauke"
+                myText: qsTr(" - German translation")
+            }
+
             VerticalScrollDecorator {}
         }
 

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -242,7 +242,7 @@ Page {
 
                             if (filePath==="") {
                                 outputNotifications.close()
-                                outputNotifications.previewBody = qsTr("Document can`t be saved!")
+                                outputNotifications.previewBody = qsTr("Document can't be saved!")
                                 outputNotifications.publish()
                             }
                         }
@@ -335,7 +335,7 @@ Page {
 
                         if (filePath==="") {
                             outputNotifications.close()
-                            outputNotifications.previewBody = qsTr("Document can`t be saved!")
+                            outputNotifications.previewBody = qsTr("Document can't be saved!")
                             outputNotifications.publish()
                         }
                     }

--- a/translations/harbour-editor-de.ts
+++ b/translations/harbour-editor-de.ts
@@ -6,242 +6,246 @@
     <message id="filemanager-la-file_details">
         <source>%1, %2</source>
         <extracomment>Shows size and modification date, e.g. &quot;15.5MB, 02/03/2016&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Zeige Größe und Modifikationsdatum, z.B. &quot;15.5MB, 02/03/2016&quot;</translation>
     </message>
     <message id="filemanager-la-no_files">
         <source>No files</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine Dateien</translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
         <source>&quot;Editor.&quot; is feature-rich text/code editor!</source>
-        <translation type="unfinished"></translation>
+        <translation>&quot;Editor.&quot; ist ein funktionsreicher Text- und Code-Editor</translation>
     </message>
     <message>
         <source>License: GPLv3</source>
-        <translation type="unfinished"></translation>
+        <translation>Lizenz: GPLv3</translation>
     </message>
     <message>
         <source>You can find the source code at the:</source>
-        <translation type="unfinished"></translation>
+        <translation>Der Quelltext befindet sich unter:</translation>
     </message>
     <message>
         <source>GitHub</source>
-        <translation type="unfinished"></translation>
+        <translation>GitHub</translation>
     </message>
     <message>
         <source>Special thanks:</source>
-        <translation type="unfinished"></translation>
+        <translation>Vielen Dank an:</translation>
     </message>
     <message>
         <source>Tips:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipps:</translation>
     </message>
     <message>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>Über</translation>
     </message>
     <message>
         <source>-coderus for various tips and code</source>
-        <translation type="unfinished"></translation>
+        <translation>• coderus für viele Tipps und Softwareentwicklung</translation>
     </message>
     <message>
         <source>-To &apos;Select all text&apos; hold your finger until 3 vibrations</source>
-        <translation type="unfinished"></translation>
+        <translation>• Berühre Text bis zur dritte Vibration, um gesamten Text auszuwählen.</translation>
     </message>
     <message>
         <source>-osanwe for very often consultations about qml code</source>
-        <translation type="unfinished"></translation>
+        <translation>• osanwe für zahllose Ratschläge zu QML-Code</translation>
     </message>
     <message>
         <source>or</source>
-        <translation type="unfinished"></translation>
+        <translation>oder</translation>
     </message>
     <message>
         <source>If you want to support the developer:</source>
-        <translation type="unfinished"></translation>
+        <translation>Wenn Du den Entwickler unterstützen willst:</translation>
     </message>
     <message>
         <source>-eekkelund for save/load/autosave functions and feedback</source>
-        <translation type="unfinished"></translation>
+        <translation>• eekkelund für Sichern-, Laden- und automatisch-Sichern-Funktionen und Feedback</translation>
     </message>
     <message>
         <source>Paypal donation</source>
-        <translation type="unfinished"></translation>
+        <translation>Paypal-Spende</translation>
     </message>
     <message>
         <source>Make a donation (button above)</source>
-        <translation type="unfinished"></translation>
+        <translation>gib eine Spende (obige Schaltfläche)</translation>
     </message>
     <message>
         <source>-Russian community for feedback and help</source>
-        <translation type="unfinished"></translation>
+        <translation>• Russische Community für Feedback und Hilfe</translation>
     </message>
     <message>
         <source>-Unsaved changes are saved in the file with ending &apos;~&apos; in the same dir where you placed your original file</source>
-        <translation type="unfinished"></translation>
+        <translation>• Ungesicherte Änderungen werden in auf &apos;~&apos; endende Datei im Verzeichnis der Originaldatei gespeichert.</translation>
     </message>
     <message>
         <source>Star the repository at the github ☺ </source>
-        <translation type="unfinished"></translation>
+        <translation>gib einen Stern auf Github ☺ </translation>
     </message>
     <message>
         <source>Translators</source>
-        <translation type="unfinished"></translation>
+        <translation>Übersetzer</translation>
     </message>
     <message>
         <source> - Spanish translation</source>
-        <translation type="unfinished"></translation>
+        <translation> • Spanische Übersetzung</translation>
     </message>
     <message>
         <source> - Swedish translation</source>
-        <translation type="unfinished"></translation>
+        <translation> • Schwedische Übersetzung</translation>
     </message>
     <message>
         <source> - Russian translation</source>
-        <translation type="unfinished"></translation>
+        <translation> • Russische Übersetzung</translation>
     </message>
     <message>
         <source> - French translation</source>
-        <translation type="unfinished"></translation>
+        <translation> • Französische Übersetzung</translation>
     </message>
     <message>
         <source> - Polish translation</source>
-        <translation type="unfinished"></translation>
+        <translation> • Polnische Übersetzung</translation>
+    </message>
+    <message>
+        <source> - German translation</source>
+        <translation> • Deutsche Übersetzung</translation>
     </message>
     <message>
         <source>-You can copy the file path to the clipboard by selecting appropriate MenuItem in pulley menu</source>
-        <translation type="unfinished"></translation>
+        <translation>• Der Dateiname kann durch Wahl des entsprechenden Menüpunktes im Zugmenü in die Zwischenablage kopiert werden.</translation>
     </message>
     <message>
         <source>-Ancelad for tab icon, testing and help</source>
-        <translation type="unfinished"></translation>
+        <translation>• Ancelad für Tabulator-Symbol, Testen und Hilfe</translation>
     </message>
 </context>
 <context>
     <name>CoverPage</name>
     <message>
         <source>Lines: </source>
-        <translation type="unfinished"></translation>
+        <translation>Zeilen: </translation>
     </message>
     <message>
         <source>Chars: </source>
-        <translation type="unfinished"></translation>
+        <translation>Zeichen: </translation>
     </message>
 </context>
 <context>
     <name>FirstPage</name>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Einstellungen</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation> </translation>
     </message>
     <message>
         <source>R-only</source>
-        <translation type="unfinished"></translation>
+        <translation> </translation>
     </message>
     <message>
         <source>Save as</source>
-        <translation type="unfinished"></translation>
+        <translation>Sichern als</translation>
     </message>
     <message>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Öffne</translation>
     </message>
     <message>
         <source>Document saved!</source>
-        <translation type="unfinished"></translation>
+        <translation>Dokument gesichert.</translation>
     </message>
     <message>
         <source>New</source>
-        <translation type="unfinished"></translation>
+        <translation>Neu</translation>
     </message>
     <message>
-        <source>Document can`t be saved!</source>
-        <translation type="unfinished"></translation>
+        <source>Document can&apos;t be saved!</source>
+        <translation>Dokument kann nicht gesichert werden!</translation>
     </message>
     <message>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation> </translation>
     </message>
     <message>
         <source>Undo</source>
-        <translation type="unfinished"></translation>
+        <translation> </translation>
     </message>
     <message>
         <source>Redo</source>
-        <translation type="unfinished"></translation>
+        <translation> </translation>
     </message>
     <message>
         <source>History</source>
-        <translation type="unfinished"></translation>
+        <translation>Chronik</translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Suche</translation>
     </message>
 </context>
 <context>
     <name>HistoryPage</name>
     <message>
         <source>History</source>
-        <translation type="unfinished"></translation>
+        <translation>Suche</translation>
     </message>
 </context>
 <context>
     <name>SettingsPage</name>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Einstellungen</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation>Erscheinungsbild</translation>
     </message>
     <message>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>Über</translation>
     </message>
     <message>
         <source>Quick menu enabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Schnellmenü aktiviert</translation>
     </message>
     <message>
         <source>Line numeration enabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeilenzählen aktiviert</translation>
     </message>
     <message>
         <source>Fonts and size</source>
-        <translation type="unfinished"></translation>
+        <translation>Schrift und Schriftgröße</translation>
     </message>
     <message>
         <source>Use it to get more space for text</source>
-        <translation type="unfinished"></translation>
+        <translation>Deaktivieren, um mehr Platz für Text zu schaffen</translation>
     </message>
     <message>
         <source>Font size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Schriftgröße:</translation>
     </message>
     <message>
         <source>Font:</source>
-        <translation type="unfinished"></translation>
+        <translation>Schrift:</translation>
     </message>
     <message>
         <source>File browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Dateimanager</translation>
     </message>
     <message>
         <source>Show hidden files</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeige versteckte Dateien</translation>
     </message>
     <message>
         <source>Be careful to enable this option!</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktivierung auf eigene Gefahr!</translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-editor-es.ts
+++ b/translations/harbour-editor-es.ts
@@ -119,6 +119,10 @@
         <source>-Ancelad for tab icon, testing and help</source>
         <translation>-Ancelad por el tab icono, pruebas y ayuda</translation>
     </message>
+    <message>
+        <source> - German translation</source>
+        <translation> - Traducción al alemana</translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -162,7 +166,7 @@
         <translation>Nuevo</translation>
     </message>
     <message>
-        <source>Document can`t be saved!</source>
+        <source>Document can&apos;t be saved!</source>
         <translation>Documento no puede ser guardado</translation>
     </message>
     <message>

--- a/translations/harbour-editor-fr.ts
+++ b/translations/harbour-editor-fr.ts
@@ -119,6 +119,10 @@
         <source>-Ancelad for tab icon, testing and help</source>
         <translation>-Ancelad pour les icônes des onglets, pour ses tests et son aide</translation>
     </message>
+    <message>
+        <source> - German translation</source>
+        <translation> - version allemande</translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -162,7 +166,7 @@
         <translation>Nouveau</translation>
     </message>
     <message>
-        <source>Document can`t be saved!</source>
+        <source>Document can&apos;t be saved!</source>
         <translation>Le document ne peut pas être enregistré !</translation>
     </message>
     <message>

--- a/translations/harbour-editor-pl.ts
+++ b/translations/harbour-editor-pl.ts
@@ -154,7 +154,7 @@
         <translation>Nowy</translation>
     </message>
     <message>
-        <source>Document can`t be saved!</source>
+        <source>Document can't be saved!</source>
         <translation>Dokument nie może być zapisany!</translation>
     </message>
     <message>

--- a/translations/harbour-editor-ru.ts
+++ b/translations/harbour-editor-ru.ts
@@ -119,6 +119,10 @@
         <source>-Ancelad for tab icon, testing and help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source> - German translation</source>
+        <translation> - немецкий перевод</translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -162,7 +166,7 @@
         <translation>Новый</translation>
     </message>
     <message>
-        <source>Document can`t be saved!</source>
+        <source>Document can&apos;t be saved!</source>
         <translation> Документ не может быть сохранен!</translation>
     </message>
     <message>
@@ -190,7 +194,7 @@
     <name>HistoryPage</name>
     <message>
         <source>History</source>
-        <translation type="unfinished">История</translation>
+        <translation>История</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-editor-sv.ts
+++ b/translations/harbour-editor-sv.ts
@@ -119,6 +119,10 @@
         <source>-Ancelad for tab icon, testing and help</source>
         <translation>Ancelad för flikikon, testning och hjälp</translation>
     </message>
+    <message>
+        <source> - German translation</source>
+        <translation> - Tysk översättning</translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -162,7 +166,7 @@
         <translation>Nytt</translation>
     </message>
     <message>
-        <source>Document can`t be saved!</source>
+        <source>Document can&apos;t be saved!</source>
         <translation>Dokumentet kan inte sparas!</translation>
     </message>
     <message>

--- a/translations/harbour-editor.ts
+++ b/translations/harbour-editor.ts
@@ -119,6 +119,10 @@
         <source>-Ancelad for tab icon, testing and help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source> - German translation</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -162,7 +166,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Document can`t be saved!</source>
+        <source>Document can&apos;t be saved!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Здравствуй Александр! Thanks for your wonderful editor. I would like to contribute a German translation and (some minor other translation related enhancements). I intentionally kept the translations for the quick menu empty. It is virtually impossible to find German translations for "Save" etc. that are short enough not to mess up the user interface. I hope the icons only are clear enough. Keeping the English labels might be an alternative to showing no labels at all but would result in an inconsistent user experience. Heiko