### PR TITLE
indicate read-only state in icon color

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -126,6 +126,7 @@ Page {
                             searched=true
                         }
                         onTextChanged: searched = false
+                        inputMethodHints: Qt.ImhNoAutoUppercase
                     }
 
                     IconButton {
@@ -250,7 +251,7 @@ Page {
 
                     MenuButton {
                         width: sizeBackgroundItemMainMenu
-                        mySource: "image://theme/icon-m-keyboard";
+                        mySource: "image://theme/icon-m-edit?" + (myTextArea.readOnly ? Theme.highlightColor : Theme.primaryColor);
                         myText: qsTr("R-only")
                         onClicked: {
                             if (myTextArea.readOnly == false) {
@@ -343,7 +344,7 @@ Page {
 
                 MenuButton {
                     width: sizeBackgroundItem
-                    mySource: "image://theme/icon-m-keyboard";
+                    mySource: "image://theme/icon-m-edit?" + (myTextArea.readOnly ? Theme.highlightColor : Theme.primaryColor);
                     myText: qsTr("R-only")
                     onClicked: {
                         if (myTextArea.readOnly == false) {

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -251,7 +251,7 @@ Page {
 
                     MenuButton {
                         width: sizeBackgroundItemMainMenu
-                        mySource: "image://theme/icon-m-edit?" + (myTextArea.readOnly ? Theme.highlightColor : Theme.primaryColor);
+                        mySource: "image://theme/icon-m-keyboard?" + (myTextArea.readOnly ? Theme.highlightColor : Theme.primaryColor);
                         myText: qsTr("R-only")
                         onClicked: {
                             if (myTextArea.readOnly == false) {
@@ -344,7 +344,7 @@ Page {
 
                 MenuButton {
                     width: sizeBackgroundItem
-                    mySource: "image://theme/icon-m-edit?" + (myTextArea.readOnly ? Theme.highlightColor : Theme.primaryColor);
+                    mySource: "image://theme/icon-m-keyboard?" + (myTextArea.readOnly ? Theme.highlightColor : Theme.primaryColor);
                     myText: qsTr("R-only")
                     onClicked: {
                         if (myTextArea.readOnly == false) {


### PR DESCRIPTION
Just a minor change to indicate the read-only state by the icon color. I also changed the icon from the keyboard icon to the pen icon, which I find more appropriate. But this might be a matter of taste. The keyboard icon is very schematic and the keyboard might not be recognized as a keyboard immediately. 