### PR TITLE
Remove dot from app name in *.desktop

### DIFF
--- a/harbour-editor.desktop
+++ b/harbour-editor.desktop
@@ -3,4 +3,4 @@ Type=Application
 X-Nemo-Application-Type=silica-qt5
 Icon=harbour-editor
 Exec=harbour-editor
-Name=Editor.
+Name=Editor


### PR DESCRIPTION
App name with dot at the end looks weird and unjustified. No other app from installed on my SfOS device have dot in launch icon.